### PR TITLE
 Use a shared lock between logger instances

### DIFF
--- a/dependency-versions.gradle
+++ b/dependency-versions.gradle
@@ -1,13 +1,13 @@
 dependencyManagement {
   dependencies {
-    dependency('io.vertx:vertx-core:3.5.0')
-    dependency('org.apache.logging.log4j:log4j-api:2.10.0')
-    dependency('org.apache.logging.log4j:log4j-core:2.10.0')
-    dependency('org.apache.logging.log4j:log4j-slf4j-impl:2.10.0')
-    dependency('org.assertj:assertj-core:3.9.0')
-    dependency('org.junit.jupiter:junit-jupiter-api:5.1.0')
-    dependency('org.junit.jupiter:junit-jupiter-params:5.1.0')
-    dependency('org.junit.jupiter:junit-jupiter-engine:5.1.0')
+    dependency('io.vertx:vertx-core:3.5.3')
+    dependency('org.apache.logging.log4j:log4j-api:2.11.0')
+    dependency('org.apache.logging.log4j:log4j-core:2.11.0')
+    dependency('org.apache.logging.log4j:log4j-slf4j-impl:2.11.0')
+    dependency('org.assertj:assertj-core:3.10.0')
+    dependency('org.junit.jupiter:junit-jupiter-api:5.2.0')
+    dependency('org.junit.jupiter:junit-jupiter-params:5.2.0')
+    dependency('org.junit.jupiter:junit-jupiter-engine:5.2.0')
     dependency('org.slf4j:slf4j-api:1.7.25')
   }
 }

--- a/logl/src/main/java/org/logl/logl/SimpleLogger.java
+++ b/logl/src/main/java/org/logl/logl/SimpleLogger.java
@@ -233,7 +233,7 @@ public final class SimpleLogger {
 
     @Override
     public AdjustableLogger getLogger(String name) {
-      return loggers.computeIfAbsent(name, n -> new SimpleLoggerImpl(n, builder, writerSupplier));
+      return loggers.computeIfAbsent(name, n -> new SimpleLoggerImpl(n, builder, writerSupplier, this));
     }
   }
 }

--- a/logl/src/main/java/org/logl/logl/SimpleLoggerImpl.java
+++ b/logl/src/main/java/org/logl/logl/SimpleLoggerImpl.java
@@ -29,13 +29,14 @@ final class SimpleLoggerImpl implements AdjustableLogger, LevelLogger {
   private final Locale locale;
   private final boolean autoFlush;
   private final Supplier<PrintWriter> writerSupplier;
+  private final Object lock;
 
   private final LevelLogWriter errorWriter;
   private final LevelLogWriter warnWriter;
   private final LevelLogWriter infoWriter;
   private final LevelLogWriter debugWriter;
 
-  SimpleLoggerImpl(String name, Builder builder, Supplier<PrintWriter> writerSupplier) {
+  SimpleLoggerImpl(String name, Builder builder, Supplier<PrintWriter> writerSupplier, Object lock) {
     this.name = NameAbbreviator.forPattern("1.").abbreviate(name);
     this.level = new AtomicReference<>(builder.level);
     this.currentTimeSupplier = builder.currentTimeSupplier;
@@ -43,6 +44,7 @@ final class SimpleLoggerImpl implements AdjustableLogger, LevelLogger {
     this.locale = builder.locale;
     this.autoFlush = builder.autoFlush;
     this.writerSupplier = writerSupplier;
+    this.lock = lock;
 
     this.errorWriter = new LevelLogWriter(Level.ERROR, this);
     this.warnWriter = new LevelLogWriter(Level.WARN, this);
@@ -229,7 +231,7 @@ final class SimpleLoggerImpl implements AdjustableLogger, LevelLogger {
     }
     Instant now = currentTimeSupplier.get();
     PrintWriter out;
-    synchronized (this) {
+    synchronized (lock) {
       out = writerSupplier.get();
       writePrefix(out, now, level);
       writeMessage(out, message);
@@ -248,7 +250,7 @@ final class SimpleLoggerImpl implements AdjustableLogger, LevelLogger {
     }
     Instant now = currentTimeSupplier.get();
     PrintWriter out;
-    synchronized (this) {
+    synchronized (lock) {
       out = writerSupplier.get();
       writePrefix(out, now, level);
       out.print(message);
@@ -268,7 +270,7 @@ final class SimpleLoggerImpl implements AdjustableLogger, LevelLogger {
     CharSequence message = messageSupplier.get();
     Instant now = currentTimeSupplier.get();
     PrintWriter out;
-    synchronized (this) {
+    synchronized (lock) {
       out = writerSupplier.get();
       writePrefix(out, now, level);
       out.print(message);
@@ -291,7 +293,7 @@ final class SimpleLoggerImpl implements AdjustableLogger, LevelLogger {
     }
     Instant now = currentTimeSupplier.get();
     PrintWriter out;
-    synchronized (this) {
+    synchronized (lock) {
       out = writerSupplier.get();
       writePrefix(out, now, level);
       writeMessage(out, message);
@@ -315,7 +317,7 @@ final class SimpleLoggerImpl implements AdjustableLogger, LevelLogger {
     }
     Instant now = currentTimeSupplier.get();
     PrintWriter out;
-    synchronized (this) {
+    synchronized (lock) {
       out = writerSupplier.get();
       writePrefix(out, now, level);
       out.print(message);
@@ -340,7 +342,7 @@ final class SimpleLoggerImpl implements AdjustableLogger, LevelLogger {
     CharSequence message = messageSupplier.get();
     Instant now = currentTimeSupplier.get();
     PrintWriter out;
-    synchronized (this) {
+    synchronized (lock) {
       out = writerSupplier.get();
       writePrefix(out, now, level);
       out.print(message);
@@ -360,7 +362,7 @@ final class SimpleLoggerImpl implements AdjustableLogger, LevelLogger {
     }
     Instant now = currentTimeSupplier.get();
     PrintWriter out;
-    synchronized (this) {
+    synchronized (lock) {
       out = writerSupplier.get();
       writePrefix(out, now, level);
       out.printf(format, args);
@@ -510,7 +512,7 @@ final class SimpleLoggerImpl implements AdjustableLogger, LevelLogger {
     }
     Level currentLevel = this.level.get();
     PrintWriter out;
-    synchronized (this) {
+    synchronized (lock) {
       out = writerSupplier.get();
       for (LogEvent logEvent : logEvents) {
         Level level = logEvent.level;

--- a/logl/src/main/java/org/logl/logl/UnformattedLogger.java
+++ b/logl/src/main/java/org/logl/logl/UnformattedLogger.java
@@ -177,7 +177,7 @@ public final class UnformattedLogger {
 
     @Override
     public AdjustableLogger getLogger(String name) {
-      return loggers.computeIfAbsent(name, n -> new UnformattedLoggerImpl(builder, writerSupplier));
+      return loggers.computeIfAbsent(name, n -> new UnformattedLoggerImpl(builder, writerSupplier, this));
     }
   }
 }

--- a/logl/src/main/java/org/logl/logl/UnformattedLoggerImpl.java
+++ b/logl/src/main/java/org/logl/logl/UnformattedLoggerImpl.java
@@ -24,17 +24,19 @@ final class UnformattedLoggerImpl implements AdjustableLogger, LevelLogger {
   private final AtomicReference<Level> level;
   private final boolean autoFlush;
   private final Supplier<PrintWriter> writerSupplier;
+  private final Object lock;
 
   private final LevelLogWriter errorWriter;
   private final LevelLogWriter warnWriter;
   private final LevelLogWriter infoWriter;
   private final LevelLogWriter debugWriter;
 
-  UnformattedLoggerImpl(Builder builder, Supplier<PrintWriter> writerSupplier) {
+  UnformattedLoggerImpl(Builder builder, Supplier<PrintWriter> writerSupplier, Object lock) {
     this.locale = builder.locale;
     this.level = new AtomicReference<>(builder.level);
     this.autoFlush = builder.autoFlush;
     this.writerSupplier = writerSupplier;
+    this.lock = lock;
 
     this.errorWriter = new LevelLogWriter(Level.ERROR, this);
     this.warnWriter = new LevelLogWriter(Level.WARN, this);
@@ -220,7 +222,7 @@ final class UnformattedLoggerImpl implements AdjustableLogger, LevelLogger {
       return;
     }
     PrintWriter out;
-    synchronized (this) {
+    synchronized (lock) {
       out = writerSupplier.get();
       writeMessage(out, message);
       out.println();
@@ -237,7 +239,7 @@ final class UnformattedLoggerImpl implements AdjustableLogger, LevelLogger {
       return;
     }
     PrintWriter out;
-    synchronized (this) {
+    synchronized (lock) {
       out = writerSupplier.get();
       out.println(message);
     }
@@ -254,7 +256,7 @@ final class UnformattedLoggerImpl implements AdjustableLogger, LevelLogger {
     }
     CharSequence message = messageSupplier.get();
     PrintWriter out;
-    synchronized (this) {
+    synchronized (lock) {
       out = writerSupplier.get();
       out.print(message);
       out.println();
@@ -272,7 +274,7 @@ final class UnformattedLoggerImpl implements AdjustableLogger, LevelLogger {
       return;
     }
     PrintWriter out;
-    synchronized (this) {
+    synchronized (lock) {
       out = writerSupplier.get();
       writeMessage(out, message);
       out.println();
@@ -294,7 +296,7 @@ final class UnformattedLoggerImpl implements AdjustableLogger, LevelLogger {
       return;
     }
     PrintWriter out;
-    synchronized (this) {
+    synchronized (lock) {
       out = writerSupplier.get();
       out.println(message);
       cause.printStackTrace(out);
@@ -316,7 +318,7 @@ final class UnformattedLoggerImpl implements AdjustableLogger, LevelLogger {
     }
     CharSequence message = messageSupplier.get();
     PrintWriter out;
-    synchronized (this) {
+    synchronized (lock) {
       out = writerSupplier.get();
       out.print(message);
       out.println();
@@ -331,7 +333,7 @@ final class UnformattedLoggerImpl implements AdjustableLogger, LevelLogger {
       return;
     }
     PrintWriter out;
-    synchronized (this) {
+    synchronized (lock) {
       out = writerSupplier.get();
       out.printf(format, args);
       out.println();
@@ -476,7 +478,7 @@ final class UnformattedLoggerImpl implements AdjustableLogger, LevelLogger {
     }
     Level currentLevel = this.level.get();
     PrintWriter out;
-    synchronized (this) {
+    synchronized (lock) {
       out = writerSupplier.get();
       for (LogEvent logEvent : logEvents) {
         if (logEvent.level.compareTo(currentLevel) > 0) {


### PR DESCRIPTION
Fixes a concurrency issue where log lines could overlap